### PR TITLE
Bump hmi-case-hq-emulator to use ingress version compatible with v1

### DIFF
--- a/charts/hmi-case-hq-emulator/Chart.yaml
+++ b/charts/hmi-case-hq-emulator/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for hmi-case-hq-emulator App
 name: hmi-case-hq-emulator
 home: https://github.com/hmcts/hmi-case-hq-emulator
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: HMCTS HMI Team
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION
### Change description ###
Bump hmi-case-hq-emulator to use ingress version compatible with v1


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
